### PR TITLE
修复PackageNotFoundError错误

### DIFF
--- a/docformat_gui.py
+++ b/docformat_gui.py
@@ -3370,6 +3370,7 @@ class DocFormatApp:
     def _on_text_generated(self, title, body_text, output_path, is_markdown=False):
         """粘贴对话框生成 docx 后的回调：触发主流程格式化。"""
         import tempfile
+        from docx import Document
 
         self.log_panel.log(f"\n{'─' * 35}", 'info')
         self.log_panel.log(f"从文本生成 docx：{title}", 'info')
@@ -3378,6 +3379,8 @@ class DocFormatApp:
         try:
             with tempfile.NamedTemporaryFile(suffix='.docx', delete=False) as tmp:
                 temp_input = tmp.name
+                tmp_doc = Document()
+                tmp_doc.save(temp_input)
             if is_markdown:
                 _create_docx_from_markdown(title, body_text, temp_input)
                 self.log_panel.log("  临时文件已生成（Markdown 格式）", 'info')
@@ -3642,7 +3645,7 @@ class DocFormatApp:
                     out_path = str(out_dir / f"{in_p.stem}_processed{in_p.suffix}")
                 else:
                     out_path = output_base
-
+                
                 self.log_panel.log(
                     f"\n[{idx + 1}/{total}] {Path(input_path).name}", 'info'
                 )
@@ -3656,6 +3659,7 @@ class DocFormatApp:
                         f"  ✓ 已保存: {Path(actual_out).name}", 'success'
                     )
                 except Exception as e:
+                    print(type(e).__name__, e)
                     self.log_panel.log(f"  ✗ 失败: {e}", 'error')
                     failed_files.append((Path(input_path).name, str(e)))
 
@@ -3757,6 +3761,8 @@ class DocFormatApp:
                 import tempfile
                 with tempfile.NamedTemporaryFile(suffix='.docx', delete=False) as tmp:
                     temp_output_docx = tmp.name
+                    tmp_doc = Document()
+                    tmp_doc.save(temp_output_docx)
                 output_path_docx = temp_output_docx
             else:
                 output_path_docx = output_path
@@ -3783,6 +3789,8 @@ class DocFormatApp:
                 import tempfile
                 with tempfile.NamedTemporaryFile(suffix='.docx', delete=False) as tmp:
                     temp_path = tmp.name
+                    tmp_doc = Document()
+                    tmp_doc.save(temp_path)
                 self.log_panel.log("步骤 1/2: 修复标点...", 'info')
                 progress_fn(0, '步骤 1/2: 修复标点...')
                 self._run_punctuation(input_path, temp_path, quiet=True, space_mode=space_mode)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 python-docx>=0.8.11
-pywin32>=305; sys_platform == 'win32'
-# 文件拖拽支持（默认安装）
-tkinterdnd2>=0.3.0; python_version >= '3.9'
+pywin32>=305
+tkinterdnd2>=0.3.0

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -137,7 +137,7 @@ def convert_to_docx(input_path, output_path=None):
     try:
         app = _create_app(prog_id)
         doc = app.Documents.Open(str(input_path))
-        doc.SaveAs2(str(output_path), FileFormat=16)
+        doc.SaveAs2(str(output_path), FileFormat=12)
         return str(output_path)
     finally:
         _safe_close(doc)


### PR DESCRIPTION
1.修复处理时报PackageNotFoundError错误
2.修改requirements.txt，现在可以运行pip3 install -r requirements.txt安装依赖
3.修复wps转docx生成docx文件存在格式问题，导致报PackageNotFoundError错误