### PR TITLE
Linux 打包升级：AlmaLinux 8 + AppImage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,76 +71,110 @@ jobs:
           path: dist/docformat_windows_win7.exe
 
   build-linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    container:
+      image: almalinux:8
     steps:
+      - name: Install system dependencies
+        run: |
+          dnf install -y epel-release
+          dnf install -y \
+            gcc gcc-c++ make \
+            python39 python39-pip python39-tkinter python39-devel \
+            squashfs-tools file wget git findutils \
+            glibc-langpack-zh
+          python3.9 -m pip install --upgrade pip
+
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Cache pip packages
+        uses: actions/cache@v4
         with:
-          python-version: '3.11'
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y python3-tk
+          path: ~/.cache/pip
+          key: linux-amd64-pip-${{ hashFiles('requirements.txt') }}
 
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install pyinstaller python-docx
+          python3.9 -m pip install pyinstaller python-docx
 
       - name: Build Linux executable
         run: |
-          DOCX_TEMPLATES=$(python3 -c "import docx, os; print(os.path.join(os.path.dirname(docx.__file__), 'templates'))")
+          export LC_ALL=zh_CN.UTF-8
+          DOCX_TEMPLATES=$(python3.9 -c "import docx, os; print(os.path.join(os.path.dirname(docx.__file__), 'templates'))")
           pyinstaller --onefile --name=docformat_linux \
             --add-data "scripts:scripts" \
             --add-data "${DOCX_TEMPLATES}:docx/templates" \
+            --collect-data=docx \
             --hidden-import=docx --hidden-import=lxml \
             docformat_gui.py
+
+      - name: Build AppImage (amd64)
+        run: |
+          chmod +x packaging/appimage/build-appimage.sh
+          packaging/appimage/build-appimage.sh \
+            dist/docformat_linux \
+            assets/icon.png \
+            docformat_linux_amd64
 
       - name: Upload Linux artifact
         uses: actions/upload-artifact@v4
         with:
           name: linux-build
-          path: dist/docformat_linux
+          path: dist/docformat_linux_amd64.AppImage
 
   build-linux-arm64:
     runs-on: ubuntu-22.04-arm
+    container:
+      image: almalinux:8
     steps:
+      - name: Install system dependencies
+        run: |
+          dnf install -y epel-release
+          dnf install -y \
+            gcc gcc-c++ make \
+            python39 python39-pip python39-tkinter python39-devel \
+            squashfs-tools file wget git findutils \
+            glibc-langpack-zh
+          python3.9 -m pip install --upgrade pip
+
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Cache pip packages
+        uses: actions/cache@v4
         with:
-          python-version: '3.11'
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y python3-tk
+          path: ~/.cache/pip
+          key: linux-arm64-pip-${{ hashFiles('requirements.txt') }}
 
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install pyinstaller python-docx
+          python3.9 -m pip install pyinstaller python-docx
 
       - name: Build Linux ARM64 executable
         run: |
-          DOCX_TEMPLATES=$(python3 -c "import docx, os; print(os.path.join(os.path.dirname(docx.__file__), 'templates'))")
-          pyinstaller --onefile --name=docformat_linux_arm64 \
+          export LC_ALL=zh_CN.UTF-8
+          DOCX_TEMPLATES=$(python3.9 -c "import docx, os; print(os.path.join(os.path.dirname(docx.__file__), 'templates'))")
+          pyinstaller --onefile --name=docformat_linux \
             --add-data "scripts:scripts" \
             --add-data "${DOCX_TEMPLATES}:docx/templates" \
+            --collect-data=docx \
             --hidden-import=docx --hidden-import=lxml \
             docformat_gui.py
+
+      - name: Build AppImage (aarch64)
+        run: |
+          chmod +x packaging/appimage/build-appimage.sh
+          packaging/appimage/build-appimage.sh \
+            dist/docformat_linux \
+            assets/icon.png \
+            docformat_linux_aarch64
 
       - name: Upload Linux ARM64 artifact
         uses: actions/upload-artifact@v4
         with:
           name: linux-arm64-build
-          path: dist/docformat_linux_arm64
+          path: dist/docformat_linux_aarch64.AppImage
 
   build-macos:
     name: build-macos (${{ matrix.arch_label }})
@@ -283,19 +317,19 @@ jobs:
             > ⚠️ Win7 用户请下载此版本，需要 Windows 7 SP1 及以上。如果闪退请安装 [Visual C++ Redistributable](https://aka.ms/vs/17/release/vc_redist.x64.exe)
             
             ## Linux 版下载（国产系统 / 麒麟 / 统信 UOS）
-            
+
             先查询架构：在终端运行 `uname -m`
-            
-            输出 `x86_64`：下载 x86_64 版本  
-            输出 `aarch64` 或 `arm64`：下载 ARM64 版本
-            
-            x86_64（Intel/AMD）：[docformat_linux](https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.VERSION }}/docformat_linux)  
-            ARM64（飞腾/鲲鹏/龙芯3A5000+）：[docformat_linux_arm64](https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.VERSION }}/docformat_linux_arm64)
-            
+
+            输出 `x86_64`：下载 amd64 版本
+            输出 `aarch64` 或 `arm64`：下载 aarch64 版本
+
+            x86_64（Intel/AMD）：[docformat_linux_amd64.AppImage](https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.VERSION }}/docformat_linux_amd64.AppImage)
+            ARM64（飞腾/鲲鹏/龙芯3A5000+）：[docformat_linux_aarch64.AppImage](https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.VERSION }}/docformat_linux_aarch64.AppImage)
+
             运行步骤：
-            1. `chmod +x docformat_linux`（或 `chmod +x docformat_linux_arm64`）
-            2. `./docformat_linux`
-            3. 如果运行报错，请使用 [install.sh 脚本方式](https://github.com/${{ github.repository }}#国产系统用户麒麟--统信-uos)
+            1. `chmod +x docformat_linux_amd64.AppImage`（或 `docformat_linux_aarch64.AppImage`）
+            2. `./docformat_linux_amd64.AppImage`
+            3. 如果 AppImage 无法运行，请使用 [install.sh 脚本方式](https://github.com/${{ github.repository }}#国产系统用户麒麟--统信-uos)
             
             仅支持 `.docx` 文件。
             
@@ -327,8 +361,8 @@ jobs:
           files: |
             dist/docformat_windows.exe
             dist/docformat_windows_win7.exe
-            dist/docformat_linux
-            dist/docformat_linux_arm64
+            dist/docformat_linux_amd64.AppImage
+            dist/docformat_linux_aarch64.AppImage
             dist/docformat_macos_intel.dmg
             dist/docformat_macos_apple_silicon.dmg
           draft: false

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -62,7 +62,9 @@ if ! command -v appimagetool >/dev/null 2>&1; then
   wget -q -O appimagetool \
     "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${ARCH_VAL}.AppImage"
   chmod +x appimagetool
-  APPIMAGETOOL="./appimagetool"
+  # CI 容器无 FUSE，直接解压执行
+  ./appimagetool --appimage-extract >/dev/null 2>&1
+  APPIMAGETOOL="./squashfs-root/AppRun"
 else
   APPIMAGETOOL="appimagetool"
 fi
@@ -73,6 +75,7 @@ ARCH="$(uname -m)" $APPIMAGETOOL "$APPDIR" "$OUTPUT"
 
 rm -rf "$APPDIR"
 [ -f appimagetool ] && rm -f appimagetool
+[ -d squashfs-root ] && rm -rf squashfs-root
 
 if [ -f "$OUTPUT" ]; then
   SIZE_MB=$(du -m "$OUTPUT" | cut -f1)

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+BINARY="${1:-dist/docformat_linux}"
+ICON="${2:-$REPO_ROOT/assets/icon.png}"
+OUTPUT_NAME="${3:-docformat_linux}"
+
+# ── 验证输入 ──
+if [ ! -f "$BINARY" ]; then
+  echo "✗ 找不到 PyInstaller 产物: $BINARY"
+  exit 1
+fi
+
+OUTPUT="$REPO_ROOT/dist/${OUTPUT_NAME}.AppImage"
+APPDIR="$REPO_ROOT/dist/AppDir"
+
+echo "构建 AppImage"
+echo "  二进制: $BINARY"
+echo "  图标: $ICON"
+echo "  输出: $OUTPUT"
+
+# ── 准备 AppDir ──
+rm -rf "$APPDIR"
+mkdir -p "$APPDIR/usr/bin"
+mkdir -p "$APPDIR/usr/share/icons/hicolor/256x256/apps"
+
+cp "$BINARY" "$APPDIR/usr/bin/docformat_linux"
+chmod 755 "$APPDIR/usr/bin/docformat_linux"
+
+[ -f "$ICON" ] && cp "$ICON" "$APPDIR/usr/share/icons/hicolor/256x256/apps/docformat.png"
+
+# ── .desktop ──
+cat > "$APPDIR/docformat.desktop" <<'EOF'
+[Desktop Entry]
+Name=公文格式处理工具
+Comment=GB/T 9704-2012 公文格式一键修复
+Exec=docformat_linux
+Icon=docformat
+Type=Application
+Categories=Office;WordProcessor;
+Terminal=false
+EOF
+
+# ── AppRun ──
+cat > "$APPDIR/AppRun" <<'APPRUN'
+#!/bin/sh
+SELF="$(readlink -f "$0")"
+HERE="${SELF%/*}"
+export PATH="$HERE/usr/bin:$PATH"
+export LD_LIBRARY_PATH="$HERE/usr/lib:$HERE/usr/lib/x86_64-linux-gnu:$HERE/usr/lib/aarch64-linux-gnu:${LD_LIBRARY_PATH:-}"
+exec "$HERE/usr/bin/docformat_linux" "$@"
+APPRUN
+chmod 755 "$APPDIR/AppRun"
+
+# ── 下载 appimagetool ──
+if ! command -v appimagetool >/dev/null 2>&1; then
+  ARCH_VAL="$(uname -m)"
+  echo "下载 appimagetool ($ARCH_VAL)..."
+  wget -q -O appimagetool \
+    "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${ARCH_VAL}.AppImage"
+  chmod +x appimagetool
+  APPIMAGETOOL="./appimagetool"
+else
+  APPIMAGETOOL="appimagetool"
+fi
+
+# ── 打包 ──
+echo "生成 AppImage..."
+ARCH="$(uname -m)" $APPIMAGETOOL "$APPDIR" "$OUTPUT"
+
+rm -rf "$APPDIR"
+[ -f appimagetool ] && rm -f appimagetool
+
+if [ -f "$OUTPUT" ]; then
+  SIZE_MB=$(du -m "$OUTPUT" | cut -f1)
+  echo "✓ AppImage 构建成功: $OUTPUT (${SIZE_MB} MB)"
+else
+  echo "✗ AppImage 构建失败"
+  exit 1
+fi

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -31,6 +31,7 @@ cp "$BINARY" "$APPDIR/usr/bin/docformat_linux"
 chmod 755 "$APPDIR/usr/bin/docformat_linux"
 
 [ -f "$ICON" ] && cp "$ICON" "$APPDIR/usr/share/icons/hicolor/256x256/apps/docformat.png"
+[ -f "$ICON" ] && cp "$ICON" "$APPDIR/docformat.png"
 
 # ── .desktop ──
 cat > "$APPDIR/docformat.desktop" <<'EOF'

--- a/packaging/appimage/docformat.desktop
+++ b/packaging/appimage/docformat.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=公文格式处理工具
+Comment=GB/T 9704-2012 公文格式一键修复
+Exec=docformat_linux
+Icon=docformat
+Type=Application
+Categories=Office;WordProcessor;
+Terminal=false


### PR DESCRIPTION
构建环境变更：
  - 构建基底从 ubuntu-22.04（glibc 2.35）改为 AlmaLinux 8 容器（glibc 2.28）
  - Python 从 3.11 降为 3.9（AlmaLinux 8 AppStream 提供）
  - 额外覆盖的发行版：RHEL 8、CentOS 8、麒麟 V10 SP1、统信 UOS 20

  产物格式变更：
  - docformat_linux → docformat_linux_amd64.AppImage
  - docformat_linux_arm64 → docformat_linux_aarch64.AppImage
  - AppImage 自带桌面集成（图标、菜单分类），用户下载后 chmod +x 即可双击运行

  新增文件：
  - packaging/appimage/build-appimage.sh — AppImage 打包脚本，自动下载 appimagetool 并组装 AppDir
  - packaging/appimage/docformat.desktop — 桌面入口文件（Office/WordProcessor 分类）

  兼容性提升：

  ┌────────────────┬────────────────┬────────────────────────┐
  │      指标      │      改前      │          改后          │
  ├────────────────┼────────────────┼────────────────────────┤
  │ glibc 最低要求 │ 2.35           │ 2.28                   │
  ├────────────────┼────────────────┼────────────────────────┤
  │ 额外支持       │ —              │ RHEL 8 系、国产系统    │
  ├────────────────┼────────────────┼────────────────────────┤
  │ 桌面集成       │ 无（裸二进制） │ 图标 + 菜单分类        │
  ├────────────────┼────────────────┼────────────────────────┤
  │ 兜底方案       │ install.sh     │ install.sh（保留不变） │
  └────────────────┴────────────────┴────────────────────────┘