### PR TITLE
fix: package portable Linux AppImages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,28 +72,30 @@ jobs:
 
   build-linux:
     runs-on: ubuntu-22.04
+    container:
+      image: almalinux:8
     steps:
+      - name: Install system dependencies
+        run: |
+          dnf install -y epel-release
+          dnf install -y \
+            gcc gcc-c++ make \
+            python39 python39-pip python39-tkinter python39-devel \
+            squashfs-tools wget git findutils \
+            glibc-langpack-zh
+          python3.9 -m pip install --upgrade pip
+
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y python3-tk
-
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install pyinstaller python-docx
+          python3.9 -m pip install pyinstaller python-docx
 
       - name: Build Linux executable
         run: |
-          DOCX_TEMPLATES=$(python3 -c "import docx, os; print(os.path.join(os.path.dirname(docx.__file__), 'templates'))")
+          export LC_ALL=zh_CN.UTF-8
+          DOCX_TEMPLATES=$(python3.9 -c "import docx, os; print(os.path.join(os.path.dirname(docx.__file__), 'templates'))")
           pyinstaller --onefile --name=docformat_linux \
             --add-data "scripts:scripts" \
             --add-data "assets/xianyu_qr.png:assets" \
@@ -101,48 +103,66 @@ jobs:
             --hidden-import=docx --hidden-import=lxml \
             docformat_gui.py
 
+      - name: Build AppImage (amd64)
+        run: |
+          chmod +x packaging/appimage/build-appimage.sh
+          packaging/appimage/build-appimage.sh \
+            dist/docformat_linux \
+            assets/icon.png \
+            docformat_linux_amd64
+
       - name: Upload Linux artifact
         uses: actions/upload-artifact@v4
         with:
           name: linux-build
-          path: dist/docformat_linux
+          path: dist/docformat_linux_amd64.AppImage
 
   build-linux-arm64:
     runs-on: ubuntu-22.04-arm
+    container:
+      image: almalinux:8
     steps:
+      - name: Install system dependencies
+        run: |
+          dnf install -y epel-release
+          dnf install -y \
+            gcc gcc-c++ make \
+            python39 python39-pip python39-tkinter python39-devel \
+            squashfs-tools wget git findutils \
+            glibc-langpack-zh
+          python3.9 -m pip install --upgrade pip
+
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y python3-tk
-
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install pyinstaller python-docx
+          python3.9 -m pip install pyinstaller python-docx
 
       - name: Build Linux ARM64 executable
         run: |
-          DOCX_TEMPLATES=$(python3 -c "import docx, os; print(os.path.join(os.path.dirname(docx.__file__), 'templates'))")
-          pyinstaller --onefile --name=docformat_linux_arm64 \
+          export LC_ALL=zh_CN.UTF-8
+          DOCX_TEMPLATES=$(python3.9 -c "import docx, os; print(os.path.join(os.path.dirname(docx.__file__), 'templates'))")
+          pyinstaller --onefile --name=docformat_linux \
             --add-data "scripts:scripts" \
             --add-data "assets/xianyu_qr.png:assets" \
             --add-data "${DOCX_TEMPLATES}:docx/templates" \
             --hidden-import=docx --hidden-import=lxml \
             docformat_gui.py
 
+      - name: Build AppImage (aarch64)
+        run: |
+          chmod +x packaging/appimage/build-appimage.sh
+          packaging/appimage/build-appimage.sh \
+            dist/docformat_linux \
+            assets/icon.png \
+            docformat_linux_aarch64
+
       - name: Upload Linux ARM64 artifact
         uses: actions/upload-artifact@v4
         with:
           name: linux-arm64-build
-          path: dist/docformat_linux_arm64
+          path: dist/docformat_linux_aarch64.AppImage
 
   build-macos:
     name: build-macos (${{ matrix.arch_label }})
@@ -288,15 +308,15 @@ jobs:
             
             先查询架构：在终端运行 `uname -m`
             
-            输出 `x86_64`：下载 x86_64 版本  
-            输出 `aarch64` 或 `arm64`：下载 ARM64 版本
+            输出 `x86_64`：下载 amd64 版本
+            输出 `aarch64` 或 `arm64`：下载 aarch64 版本
             
-            x86_64（Intel/AMD）：[docformat_linux](https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.VERSION }}/docformat_linux)  
-            ARM64（飞腾/鲲鹏/龙芯3A5000+）：[docformat_linux_arm64](https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.VERSION }}/docformat_linux_arm64)
+            x86_64（Intel/AMD）：[docformat_linux_amd64.AppImage](https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.VERSION }}/docformat_linux_amd64.AppImage)
+            ARM64（飞腾/鲲鹏/龙芯3A5000+）：[docformat_linux_aarch64.AppImage](https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.VERSION }}/docformat_linux_aarch64.AppImage)
             
             运行步骤：
-            1. `chmod +x docformat_linux`（或 `chmod +x docformat_linux_arm64`）
-            2. `./docformat_linux`
+            1. `chmod +x docformat_linux_amd64.AppImage`（或 `docformat_linux_aarch64.AppImage`）
+            2. `./docformat_linux_amd64.AppImage`
             3. 如果运行报错，请使用 [install.sh 脚本方式](https://github.com/${{ github.repository }}#国产系统用户麒麟--统信-uos)
             
             仅支持 `.docx` 文件。
@@ -332,8 +352,8 @@ jobs:
           files: |
             dist/docformat_windows.exe
             dist/docformat_windows_win7.exe
-            dist/docformat_linux
-            dist/docformat_linux_arm64
+            dist/docformat_linux_amd64.AppImage
+            dist/docformat_linux_aarch64.AppImage
             dist/docformat_macos_intel.dmg
             dist/docformat_macos_apple_silicon.dmg
           draft: false

--- a/README.md
+++ b/README.md
@@ -142,16 +142,16 @@ uname -m
 
 | 输出结果 | 适用硬件 | 下载链接 |
 |---|---|---|
-| `x86_64` | Intel / AMD / 兆芯 / 海光 | [**docformat_linux**](https://github.com/KaguraNanaga/docformat-gui/releases/latest/download/docformat_linux) |
-| `aarch64` | 飞腾 / 鲲鹏 / 树莓派 | [**docformat_linux_arm64**](https://github.com/KaguraNanaga/docformat-gui/releases/latest/download/docformat_linux_arm64) |
+| `x86_64` | Intel / AMD / 兆芯 / 海光 | [**docformat_linux_amd64.AppImage**](https://github.com/KaguraNanaga/docformat-gui/releases/latest/download/docformat_linux_amd64.AppImage) |
+| `aarch64` | 飞腾 / 鲲鹏 / 树莓派 | [**docformat_linux_aarch64.AppImage**](https://github.com/KaguraNanaga/docformat-gui/releases/latest/download/docformat_linux_aarch64.AppImage) |
 
 **第二步：赋予执行权限并运行**
 ```bash
-chmod +x docformat_linux          # ARM64 用户替换为 docformat_linux_arm64
-./docformat_linux
+chmod +x docformat_linux_amd64.AppImage   # ARM64 用户替换为 docformat_linux_aarch64.AppImage
+./docformat_linux_amd64.AppImage
 ```
 
-> 如果双击无反应，请在文件管理器中右键 → 属性 → 勾选"允许作为程序执行"
+> 如果双击无反应，请在文件管理器中右键 → 属性 → 勾选"允许作为程序执行"。部分系统缺少 FUSE 时，可运行 `./docformat_linux_amd64.AppImage --appimage-extract-and-run`，或改用源码运行方式。
 
 #### 方式二：源码运行（binary 报错时的备选）
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -65,9 +65,9 @@ This tool is more than just a simple format painter. It deeply analyzes and fixe
 > * Supports `.docx`, `.doc`, and `.wps` format documents.
 
 ### Linux Users (Kylin / UOS)
-1. **Click to Download**: [**Document_Format_GUI_Linux**](https://github.com/KaguraNanaga/docformat-gui/releases/latest/download/docformat_linux)
-2. Grant execute permission: `chmod +x docformat_linux`
-3. Double-click to run or execute: `./docformat_linux`
+1. **Click to Download**: [**Linux x86_64 AppImage**](https://github.com/KaguraNanaga/docformat-gui/releases/latest/download/docformat_linux_amd64.AppImage) or [**Linux ARM64 AppImage**](https://github.com/KaguraNanaga/docformat-gui/releases/latest/download/docformat_linux_aarch64.AppImage)
+2. Grant execute permission: `chmod +x docformat_linux_amd64.AppImage`
+3. Double-click to run or execute: `./docformat_linux_amd64.AppImage`
 
 > **Note**:
 > * The Linux build supports `.docx` only. Convert `.doc/.wps` to `.docx` on Windows first.

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+APPIMAGETOOL_VERSION=1.9.1
+
+BINARY="${1:-$REPO_ROOT/dist/docformat_linux}"
+ICON="${2:-$REPO_ROOT/assets/icon.png}"
+OUTPUT_NAME="${3:-docformat_linux}"
+OUTPUT="$REPO_ROOT/dist/${OUTPUT_NAME}.AppImage"
+APPDIR="$(mktemp -d "$REPO_ROOT/dist/appdir.XXXXXX")"
+TOOL_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$APPDIR" "$TOOL_DIR"
+}
+trap cleanup EXIT
+
+if [ ! -f "$BINARY" ]; then
+  echo "✗ 找不到 PyInstaller 产物: $BINARY"
+  exit 1
+fi
+if [ ! -f "$ICON" ]; then
+  echo "✗ 找不到应用图标: $ICON"
+  exit 1
+fi
+
+ARCH_VALUE="$(uname -m)"
+case "$ARCH_VALUE" in
+  x86_64|aarch64) ;;
+  *)
+    echo "✗ 不支持的 AppImage 架构: $ARCH_VALUE"
+    exit 1
+    ;;
+esac
+
+mkdir -p "$APPDIR/usr/bin" "$APPDIR/usr/share/icons/hicolor/256x256/apps"
+install -m 755 "$BINARY" "$APPDIR/usr/bin/docformat_linux"
+install -m 644 "$ICON" "$APPDIR/usr/share/icons/hicolor/256x256/apps/docformat.png"
+install -m 644 "$ICON" "$APPDIR/docformat.png"
+install -m 644 "$SCRIPT_DIR/docformat.desktop" "$APPDIR/docformat.desktop"
+
+cat > "$APPDIR/AppRun" <<'APPRUN'
+#!/bin/sh
+HERE="$(dirname "$(readlink -f "$0")")"
+export PATH="$HERE/usr/bin:$PATH"
+exec "$HERE/usr/bin/docformat_linux" "$@"
+APPRUN
+chmod 755 "$APPDIR/AppRun"
+
+TOOL="$TOOL_DIR/appimagetool"
+TOOL_URL="https://github.com/AppImage/appimagetool/releases/download/${APPIMAGETOOL_VERSION}/appimagetool-${ARCH_VALUE}.AppImage"
+echo "下载 appimagetool ${APPIMAGETOOL_VERSION} ($ARCH_VALUE)..."
+wget -q -O "$TOOL" "$TOOL_URL"
+chmod 755 "$TOOL"
+
+# GitHub Actions container has no FUSE. Extract the tool before invoking it.
+(
+  cd "$TOOL_DIR"
+  "$TOOL" --appimage-extract >/dev/null
+)
+
+rm -f "$OUTPUT"
+echo "生成 AppImage: $OUTPUT"
+ARCH="$ARCH_VALUE" "$TOOL_DIR/squashfs-root/AppRun" "$APPDIR" "$OUTPUT"
+
+test -f "$OUTPUT"
+echo "✓ AppImage 构建成功: $OUTPUT"

--- a/packaging/appimage/docformat.desktop
+++ b/packaging/appimage/docformat.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=公文格式处理工具
+Comment=GB/T 9704-2012 公文格式一键修复
+Exec=docformat_linux
+Icon=docformat
+Type=Application
+Categories=Office;WordProcessor;
+Terminal=false

--- a/tests/test_linux_appimage_packaging.py
+++ b/tests/test_linux_appimage_packaging.py
@@ -1,0 +1,26 @@
+"""Release workflow safeguards for portable Linux artifacts."""
+
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).parent.parent
+
+
+def test_linux_workflow_builds_appimages_with_the_community_notice_asset():
+    workflow = (PROJECT_ROOT / ".github" / "workflows" / "build.yml").read_text(encoding="utf-8")
+
+    assert workflow.count("image: almalinux:8") == 2
+    assert workflow.count('assets/xianyu_qr.png:assets') >= 2
+    assert "packaging/appimage/build-appimage.sh" in workflow
+    assert "docformat_linux_amd64.AppImage" in workflow
+    assert "docformat_linux_aarch64.AppImage" in workflow
+
+
+def test_appimage_builder_uses_a_pinned_tool_release_and_cleans_only_temp_dirs():
+    script = (PROJECT_ROOT / "packaging" / "appimage" / "build-appimage.sh").read_text(encoding="utf-8")
+
+    assert "APPIMAGETOOL_VERSION=1.9.1" in script
+    assert "releases/download/${APPIMAGETOOL_VERSION}" in script
+    assert "mktemp -d" in script
+    assert "trap cleanup EXIT" in script
+    assert "docformat.desktop" in script


### PR DESCRIPTION
## 内容

- 在 AlmaLinux 8 容器中构建 x86_64 与 ARM64 AppImage
- 固定 appimagetool 1.9.1，避免浮动 continuous 下载
- 保留社区版官方渠道二维码资源，并增加打包回归测试
- 更新 Linux 下载和运行说明

## 验证

- `pytest -q`（36 passed）
- `bash -n packaging/appimage/build-appimage.sh`
- Actions workflow YAML 解析通过

实际 AppImage 产物会在标签构建中由 GitHub Actions 验证。