### PR TITLE
fix: install AppImage file dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
           dnf install -y \
             gcc gcc-c++ make \
             python39 python39-pip python39-tkinter python39-devel \
-            squashfs-tools wget git findutils \
+            squashfs-tools wget git findutils file \
             glibc-langpack-zh
           python3.9 -m pip install --upgrade pip
 
@@ -128,7 +128,7 @@ jobs:
           dnf install -y \
             gcc gcc-c++ make \
             python39 python39-pip python39-tkinter python39-devel \
-            squashfs-tools wget git findutils \
+            squashfs-tools wget git findutils file \
             glibc-langpack-zh
           python3.9 -m pip install --upgrade pip
 

--- a/tests/test_linux_appimage_packaging.py
+++ b/tests/test_linux_appimage_packaging.py
@@ -11,6 +11,7 @@ def test_linux_workflow_builds_appimages_with_the_community_notice_asset():
 
     assert workflow.count("image: almalinux:8") == 2
     assert workflow.count('assets/xianyu_qr.png:assets') >= 2
+    assert workflow.count("squashfs-tools wget git findutils file") == 2
     assert "packaging/appimage/build-appimage.sh" in workflow
     assert "docformat_linux_amd64.AppImage" in workflow
     assert "docformat_linux_aarch64.AppImage" in workflow


### PR DESCRIPTION
## 修复

AlmaLinux 8 镜像没有预装 `file`，导致固定版本的 appimagetool 在生成 AppImage 前退出。为两个 Linux 作业显式安装该包，并加入回归断言。

## 验证

- `pytest -q tests/test_linux_appimage_packaging.py`（2 passed）
- `git diff --check`